### PR TITLE
prevent jobs from running if external binary is missing

### DIFF
--- a/Vod2Tube.Api/Controllers/SettingsController.cs
+++ b/Vod2Tube.Api/Controllers/SettingsController.cs
@@ -6,16 +6,21 @@ namespace Vod2Tube.Api.Controllers;
 
 [ApiController]
 [Route("api/settings")]
-public class SettingsController(SettingsService settingsSvc) : ControllerBase
+public class SettingsController(SettingsService settingsSvc, ExecutableReadinessMonitor executableReadinessMonitor) : ControllerBase
 {
     [HttpGet]
     public async Task<IResult> Get()
         => Results.Ok(await settingsSvc.GetSettingsAsync());
 
+    [HttpGet("executables")]
+    public IResult GetExecutableStatus()
+        => Results.Ok(executableReadinessMonitor.CurrentStatus);
+
     [HttpPut]
     public async Task<IResult> Update(AppSettings incoming)
     {
         await settingsSvc.SaveSettingsAsync(incoming);
+        await executableReadinessMonitor.RefreshAsync(HttpContext.RequestAborted);
         return Results.Ok(await settingsSvc.GetSettingsAsync());
     }
 }

--- a/Vod2Tube.Api/Program.cs
+++ b/Vod2Tube.Api/Program.cs
@@ -24,6 +24,7 @@ builder.Services.AddTransient<AppDbContext>(sp =>
 builder.Services.AddOptions<AppSettings>();
 builder.Services.AddSingleton<IConfigureOptions<AppSettings>, AppSettingsConfigurator>();
 builder.Services.AddScoped<SettingsService>();
+builder.Services.AddSingleton<ExecutableReadinessMonitor>();
 
 builder.Services.AddScoped<ChannelService>();
 builder.Services.AddScoped<YouTubeAccountService>();
@@ -37,6 +38,7 @@ builder.Services.AddScoped<VideoUploader>();
 builder.Services.AddScoped<VodDownloader>();
 builder.Services.AddScoped<Archiver>();
 
+builder.Services.AddHostedService(sp => sp.GetRequiredService<ExecutableReadinessMonitor>());
 builder.Services.AddHostedService<VodPopulator>();
 builder.Services.AddHostedService<JobManager>();
 

--- a/Vod2Tube.Application/JobManager.cs
+++ b/Vod2Tube.Application/JobManager.cs
@@ -105,6 +105,8 @@ namespace Vod2Tube.Application
 
         private async Task<bool> WaitForExecutableReadinessAsync(CancellationToken ct)
         {
+            string? lastLoggedMissingTools = null;
+
             while (!ct.IsCancellationRequested)
             {
                 var status = _executableReadinessMonitor.CurrentStatus;
@@ -117,9 +119,20 @@ namespace Vod2Tube.Application
                 if (status.IsReady)
                     return true;
 
-                _logger.LogWarning(
-                    "Job processing is paused because required executables are unavailable: {MissingTools}",
-                    string.Join(", ", status.RequiredExecutables.Where(x => !x.Exists).Select(x => x.DisplayName)));
+                var missingTools = string.Join(", ", status.RequiredExecutables.Where(x => !x.Exists).Select(x => x.DisplayName));
+                if (missingTools != lastLoggedMissingTools)
+                {
+                    _logger.LogWarning(
+                        "Job processing is paused because required executables are unavailable: {MissingTools}",
+                        missingTools);
+                    lastLoggedMissingTools = missingTools;
+                }
+                else
+                {
+                    _logger.LogDebug(
+                        "Still waiting for required executables: {MissingTools}",
+                        missingTools);
+                }
 
                 await Task.Delay(TimeSpan.FromSeconds(10), ct);
             }

--- a/Vod2Tube.Application/JobManager.cs
+++ b/Vod2Tube.Application/JobManager.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Vod2Tube.Application.Models;
 using Vod2Tube.Application.PipelineWorkers;
+using Vod2Tube.Application.Services;
 using Vod2Tube.Domain;
 using Vod2Tube.Infrastructure;
 
@@ -13,6 +14,7 @@ namespace Vod2Tube.Application
     {
         private readonly IServiceScopeFactory _scopeFactory;
         private readonly ILogger<JobManager> _logger;
+        private readonly ExecutableReadinessMonitor _executableReadinessMonitor;
 
         // Maximum number of total attempts before a transient failure is treated as permanent.
         internal const int MaxRetryAttempts = 3;
@@ -34,10 +36,14 @@ namespace Vod2Tube.Application
             "Archiving"
         ];
 
-        public JobManager(IServiceScopeFactory scopeFactory, ILogger<JobManager> logger)
+        public JobManager(
+            IServiceScopeFactory scopeFactory,
+            ILogger<JobManager> logger,
+            ExecutableReadinessMonitor executableReadinessMonitor)
         {
             _scopeFactory = scopeFactory;
             _logger = logger;
+            _executableReadinessMonitor = executableReadinessMonitor;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -47,6 +53,9 @@ namespace Vod2Tube.Application
             {
                 try
                 {
+                    if (!await WaitForExecutableReadinessAsync(stoppingToken))
+                        break;
+
                     await using var scope = _scopeFactory.CreateAsyncScope();
                     var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
 
@@ -67,6 +76,9 @@ namespace Vod2Tube.Application
                         _logger.LogInformation("Job {VodId} is paused; waiting for it to be unpaused", job.VodId);
                         while (!stoppingToken.IsCancellationRequested)
                         {
+                            if (!await WaitForExecutableReadinessAsync(stoppingToken))
+                                return;
+
                             await Task.Delay(TimeSpan.FromSeconds(10), stoppingToken);
                             if (!await IsJobPausedAsync(dbContext, job.VodId, stoppingToken))
                             {
@@ -89,6 +101,30 @@ namespace Vod2Tube.Application
                 }
             }
             _logger.LogInformation("JobManager stopped");
+        }
+
+        private async Task<bool> WaitForExecutableReadinessAsync(CancellationToken ct)
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                var status = _executableReadinessMonitor.CurrentStatus;
+                if (status.IsReady)
+                    return true;
+
+                if (status.CheckedAtUtc == DateTimeOffset.MinValue)
+                    status = await _executableReadinessMonitor.RefreshAsync(ct);
+
+                if (status.IsReady)
+                    return true;
+
+                _logger.LogWarning(
+                    "Job processing is paused because required executables are unavailable: {MissingTools}",
+                    string.Join(", ", status.RequiredExecutables.Where(x => !x.Exists).Select(x => x.DisplayName)));
+
+                await Task.Delay(TimeSpan.FromSeconds(10), ct);
+            }
+
+            return false;
         }
 
         internal static async Task<Pipeline?> FindHighestPriorityJobAsync(AppDbContext dbContext, CancellationToken ct)

--- a/Vod2Tube.Application/Models/ExecutableReadinessStatus.cs
+++ b/Vod2Tube.Application/Models/ExecutableReadinessStatus.cs
@@ -1,0 +1,19 @@
+namespace Vod2Tube.Application.Models;
+
+public sealed class ExecutableReadinessStatus
+{
+    public bool IsReady { get; init; }
+    public DateTimeOffset CheckedAtUtc { get; init; }
+    public IReadOnlyList<ExecutableRequirementStatus> RequiredExecutables { get; init; } = [];
+    public string Message => IsReady
+        ? "All required third-party executables are available."
+        : "One or more required third-party executables are missing. Update the configured tool paths in Settings before running jobs.";
+}
+
+public sealed class ExecutableRequirementStatus
+{
+    public required string SettingName { get; init; }
+    public required string DisplayName { get; init; }
+    public required string Path { get; init; }
+    public bool Exists { get; init; }
+}

--- a/Vod2Tube.Application/Services/ExecutableReadinessMonitor.cs
+++ b/Vod2Tube.Application/Services/ExecutableReadinessMonitor.cs
@@ -42,7 +42,7 @@ public sealed class ExecutableReadinessMonitor : BackgroundService
     {
         await using var scope = _scopeFactory.CreateAsyncScope();
         var settingsService = scope.ServiceProvider.GetRequiredService<SettingsService>();
-        var settings = await settingsService.GetSettingsAsync();
+        var settings = await settingsService.GetSettingsAsync(cancellationToken);
 
         var status = BuildStatus(settings);
         var previous = CurrentStatus;

--- a/Vod2Tube.Application/Services/ExecutableReadinessMonitor.cs
+++ b/Vod2Tube.Application/Services/ExecutableReadinessMonitor.cs
@@ -1,0 +1,129 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Vod2Tube.Application.Models;
+
+namespace Vod2Tube.Application.Services;
+
+public sealed class ExecutableReadinessMonitor : BackgroundService
+{
+    private static readonly TimeSpan RefreshInterval = TimeSpan.FromSeconds(15);
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<ExecutableReadinessMonitor> _logger;
+    private readonly Lock _statusLock = new();
+    private ExecutableReadinessStatus _currentStatus = new()
+    {
+        IsReady = false,
+        CheckedAtUtc = DateTimeOffset.MinValue,
+        RequiredExecutables = []
+    };
+
+    public ExecutableReadinessMonitor(IServiceScopeFactory scopeFactory, ILogger<ExecutableReadinessMonitor> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public ExecutableReadinessStatus CurrentStatus
+    {
+        get
+        {
+            lock (_statusLock)
+            {
+                return _currentStatus;
+            }
+        }
+    }
+
+    public bool IsReady => CurrentStatus.IsReady;
+
+    public async Task<ExecutableReadinessStatus> RefreshAsync(CancellationToken cancellationToken = default)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var settingsService = scope.ServiceProvider.GetRequiredService<SettingsService>();
+        var settings = await settingsService.GetSettingsAsync();
+
+        var status = BuildStatus(settings);
+        var previous = CurrentStatus;
+
+        lock (_statusLock)
+        {
+            _currentStatus = status;
+        }
+
+        if (status.IsReady != previous.IsReady)
+        {
+            if (status.IsReady)
+            {
+                _logger.LogInformation("Executable readiness restored. All required tools are available.");
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Executable readiness check failed. Missing tools: {MissingTools}",
+                    string.Join(", ", status.RequiredExecutables.Where(x => !x.Exists).Select(x => x.DisplayName)));
+            }
+        }
+
+        return status;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await RefreshSafelyAsync(stoppingToken);
+
+        using var timer = new PeriodicTimer(RefreshInterval);
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            await RefreshSafelyAsync(stoppingToken);
+        }
+    }
+
+    private async Task RefreshSafelyAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await RefreshAsync(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Executable readiness refresh failed.");
+        }
+    }
+
+    internal static ExecutableReadinessStatus BuildStatus(AppSettings settings)
+    {
+        var executables = new[]
+        {
+            CreateRequirement(nameof(AppSettings.TwitchDownloaderCliPath), "TwitchDownloaderCLI", settings.TwitchDownloaderCliPath),
+            CreateRequirement(nameof(AppSettings.FfmpegPath), "FFmpeg", settings.FfmpegPath),
+            CreateRequirement(nameof(AppSettings.FfprobePath), "FFprobe", settings.FfprobePath),
+            CreateRequirement(nameof(AppSettings.YtDlpPath), "yt-dlp", settings.YtDlpPath),
+        };
+
+        return new ExecutableReadinessStatus
+        {
+            IsReady = executables.All(x => x.Exists),
+            CheckedAtUtc = DateTimeOffset.UtcNow,
+            RequiredExecutables = executables
+        };
+    }
+
+    private static ExecutableRequirementStatus CreateRequirement(string settingName, string displayName, string path)
+    {
+        var normalizedPath = path?.Trim() ?? string.Empty;
+
+        return new ExecutableRequirementStatus
+        {
+            SettingName = settingName,
+            DisplayName = displayName,
+            Path = normalizedPath,
+            Exists = !string.IsNullOrWhiteSpace(normalizedPath) && File.Exists(normalizedPath)
+        };
+    }
+}

--- a/Vod2Tube.Application/Services/SettingsService.cs
+++ b/Vod2Tube.Application/Services/SettingsService.cs
@@ -20,9 +20,9 @@ namespace Vod2Tube.Application.Services
         /// Returns the current settings.  Any key not present in the database
         /// will fall back to its <see cref="AppSettings"/> default value.
         /// </summary>
-        public async Task<AppSettings> GetSettingsAsync()
+        public async Task<AppSettings> GetSettingsAsync(CancellationToken cancellationToken = default)
         {
-            var rows = await _db.Settings.AsNoTracking().ToListAsync();
+            var rows = await _db.Settings.AsNoTracking().ToListAsync(cancellationToken);
             var dict = rows.ToDictionary(s => s.Key, s => s.Value);
             var settings = new AppSettings();
             AppSettings.ApplyDictionary(settings, dict);

--- a/Vod2Tube.Console/Program.cs
+++ b/Vod2Tube.Console/Program.cs
@@ -36,6 +36,8 @@ try
         .UseSerilog()
         .ConfigureServices((context, services) =>
         {
+            services.AddSingleton<ExecutableReadinessMonitor>();
+            services.AddHostedService(sp => sp.GetRequiredService<ExecutableReadinessMonitor>());
             services.AddHostedService<JobManager>();
 
             services.AddHostedService<VodPopulator>();

--- a/Vod2Tube.React/src/api/client.ts
+++ b/Vod2Tube.React/src/api/client.ts
@@ -171,8 +171,23 @@ export interface AppSettings {
   archiveFinalVideoDir: string;
 }
 
+export interface ExecutableRequirementStatus {
+  settingName: string;
+  displayName: string;
+  path: string;
+  exists: boolean;
+}
+
+export interface ExecutableReadinessStatus {
+  isReady: boolean;
+  checkedAtUtc: string;
+  message: string;
+  requiredExecutables: ExecutableRequirementStatus[];
+}
+
 export const settingsApi = {
   get: () => request<AppSettings>('/settings'),
+  getExecutableStatus: () => request<ExecutableReadinessStatus>('/settings/executables'),
   save: (settings: AppSettings) =>
     request<AppSettings>('/settings', {
       method: 'PUT',

--- a/Vod2Tube.React/src/components/Layout.tsx
+++ b/Vod2Tube.React/src/components/Layout.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useState } from 'react';
 import { NavLink } from 'react-router-dom';
+import { settingsApi, type ExecutableReadinessStatus } from '../api/client';
 
 interface NavItem {
   to: string;
@@ -14,6 +16,35 @@ const NAV: NavItem[] = [
 ];
 
 export default function Layout({ children }: { children: React.ReactNode }) {
+  const [readiness, setReadiness] = useState<ExecutableReadinessStatus | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const status = await settingsApi.getExecutableStatus();
+        if (!cancelled) {
+          setReadiness(status);
+        }
+      } catch {
+        if (!cancelled) {
+          setReadiness(null);
+        }
+      }
+    };
+
+    load();
+    const timer = window.setInterval(load, 15000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, []);
+
+  const missingExecutables = readiness?.requiredExecutables.filter(x => !x.exists) ?? [];
+
   return (
     <div className="min-h-screen bg-surface text-on-surface antialiased selection:bg-primary/30 selection:text-primary">
       {/* ── Top Nav Bar ──────────────────────────────────────────── */}
@@ -108,6 +139,30 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
         {/* ── Main Content Canvas ──────────────────────────────── */}
         <main className="flex-1 md:ml-64 p-8 min-h-screen bg-surface">
+          {readiness && !readiness.isReady && (
+            <div className="mb-6 rounded-xl border border-amber-400/25 bg-amber-500/10 px-5 py-4 text-sm text-amber-100 shadow-[0_8px_30px_rgba(245,158,11,0.08)]">
+              <div className="flex items-start gap-3">
+                <span className="material-symbols-outlined mt-0.5 text-xl text-amber-300">warning</span>
+                <div className="flex-1">
+                  <h2 className="font-semibold text-amber-50">Required tools need attention</h2>
+                  <p className="mt-1 text-amber-100/90">
+                    {readiness.message} Automated jobs are temporarily paused until these paths point to valid executables.
+                  </p>
+                  <ul className="mt-3 space-y-1 text-amber-100/85">
+                    {missingExecutables.map(executable => (
+                      <li key={executable.settingName} className="flex flex-wrap items-baseline gap-2">
+                        <span className="font-medium text-amber-50">{executable.displayName}</span>
+                        <span className="font-mono text-xs break-all">{executable.path || 'Path not configured'}</span>
+                      </li>
+                    ))}
+                  </ul>
+                  <p className="mt-3 text-xs uppercase tracking-widest text-amber-200/70">
+                    Rechecked automatically every 15 seconds
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
           {children}
         </main>
       </div>

--- a/Vod2Tube.React/src/components/Layout.tsx
+++ b/Vod2Tube.React/src/components/Layout.tsx
@@ -46,7 +46,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
     return () => {
       cancelled = true;
-      clearTimeout(timer);
+      if (timer !== undefined) clearTimeout(timer);
     };
   }, []);
 

--- a/Vod2Tube.React/src/components/Layout.tsx
+++ b/Vod2Tube.React/src/components/Layout.tsx
@@ -20,6 +20,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
 
     const load = async () => {
       try {
@@ -34,12 +35,18 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       }
     };
 
-    load();
-    const timer = window.setInterval(load, 15000);
+    const poll = async () => {
+      await load();
+      if (!cancelled) {
+        timer = setTimeout(poll, 15000);
+      }
+    };
+
+    poll();
 
     return () => {
       cancelled = true;
-      window.clearInterval(timer);
+      clearTimeout(timer);
     };
   }, []);
 

--- a/Vod2Tube.Tests/Application/ExecutableReadinessMonitorTests.cs
+++ b/Vod2Tube.Tests/Application/ExecutableReadinessMonitorTests.cs
@@ -1,0 +1,182 @@
+using TUnit.Core;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+using Vod2Tube.Application;
+using Vod2Tube.Application.Services;
+
+namespace Vod2Tube.Tests.Application;
+
+/// <summary>
+/// Unit tests for <see cref="ExecutableReadinessMonitor.BuildStatus"/>.
+/// </summary>
+public class ExecutableReadinessMonitorTests
+{
+    // =========================================================================
+    // BuildStatus — IsReady
+    // =========================================================================
+
+    [Test]
+    public async Task BuildStatus_AllPathsExist_IsReadyTrue()
+    {
+        string f1 = Path.GetTempFileName();
+        string f2 = Path.GetTempFileName();
+        string f3 = Path.GetTempFileName();
+        string f4 = Path.GetTempFileName();
+        try
+        {
+            var settings = new AppSettings
+            {
+                TwitchDownloaderCliPath = f1,
+                FfmpegPath  = f2,
+                FfprobePath = f3,
+                YtDlpPath   = f4,
+            };
+
+            var status = ExecutableReadinessMonitor.BuildStatus(settings);
+
+            await Assert.That(status.IsReady).IsTrue();
+        }
+        finally
+        {
+            File.Delete(f1); File.Delete(f2); File.Delete(f3); File.Delete(f4);
+        }
+    }
+
+    [Test]
+    public async Task BuildStatus_AllPathsMissing_IsReadyFalse()
+    {
+        var settings = new AppSettings
+        {
+            TwitchDownloaderCliPath = "/nonexistent/TwitchDownloaderCLI",
+            FfmpegPath  = "/nonexistent/ffmpeg",
+            FfprobePath = "/nonexistent/ffprobe",
+            YtDlpPath   = "/nonexistent/yt-dlp",
+        };
+
+        var status = ExecutableReadinessMonitor.BuildStatus(settings);
+
+        await Assert.That(status.IsReady).IsFalse();
+    }
+
+    [Test]
+    public async Task BuildStatus_SomePathsMissing_IsReadyFalse()
+    {
+        string existingFile = Path.GetTempFileName();
+        try
+        {
+            var settings = new AppSettings
+            {
+                TwitchDownloaderCliPath = existingFile,
+                FfmpegPath  = existingFile,
+                FfprobePath = "/nonexistent/ffprobe",
+                YtDlpPath   = "/nonexistent/yt-dlp",
+            };
+
+            var status = ExecutableReadinessMonitor.BuildStatus(settings);
+
+            await Assert.That(status.IsReady).IsFalse();
+        }
+        finally
+        {
+            File.Delete(existingFile);
+        }
+    }
+
+    [Test]
+    public async Task BuildStatus_EmptyPaths_IsReadyFalse()
+    {
+        var settings = new AppSettings
+        {
+            TwitchDownloaderCliPath = "",
+            FfmpegPath  = "",
+            FfprobePath = "",
+            YtDlpPath   = "",
+        };
+
+        var status = ExecutableReadinessMonitor.BuildStatus(settings);
+
+        await Assert.That(status.IsReady).IsFalse();
+    }
+
+    // =========================================================================
+    // BuildStatus — RequiredExecutables
+    // =========================================================================
+
+    [Test]
+    public async Task BuildStatus_RequiredExecutables_ContainsAllFourTools()
+    {
+        var status = ExecutableReadinessMonitor.BuildStatus(new AppSettings());
+
+        await Assert.That(status.RequiredExecutables).Count().IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task BuildStatus_RequiredExecutables_HaveExpectedDisplayNames()
+    {
+        var status = ExecutableReadinessMonitor.BuildStatus(new AppSettings());
+
+        var names = status.RequiredExecutables.Select(x => x.DisplayName).ToArray();
+        await Assert.That(names).Contains("TwitchDownloaderCLI");
+        await Assert.That(names).Contains("FFmpeg");
+        await Assert.That(names).Contains("FFprobe");
+        await Assert.That(names).Contains("yt-dlp");
+    }
+
+    [Test]
+    public async Task BuildStatus_MissingExecutables_HaveExistsFalse()
+    {
+        var settings = new AppSettings
+        {
+            TwitchDownloaderCliPath = "/nonexistent/TwitchDownloaderCLI",
+            FfmpegPath  = "/nonexistent/ffmpeg",
+            FfprobePath = "/nonexistent/ffprobe",
+            YtDlpPath   = "/nonexistent/yt-dlp",
+        };
+
+        var status = ExecutableReadinessMonitor.BuildStatus(settings);
+
+        await Assert.That(status.RequiredExecutables.All(x => !x.Exists)).IsTrue();
+    }
+
+    [Test]
+    public async Task BuildStatus_ExistingExecutables_HaveExistsTrue()
+    {
+        string f1 = Path.GetTempFileName();
+        string f2 = Path.GetTempFileName();
+        string f3 = Path.GetTempFileName();
+        string f4 = Path.GetTempFileName();
+        try
+        {
+            var settings = new AppSettings
+            {
+                TwitchDownloaderCliPath = f1,
+                FfmpegPath  = f2,
+                FfprobePath = f3,
+                YtDlpPath   = f4,
+            };
+
+            var status = ExecutableReadinessMonitor.BuildStatus(settings);
+
+            await Assert.That(status.RequiredExecutables.All(x => x.Exists)).IsTrue();
+        }
+        finally
+        {
+            File.Delete(f1); File.Delete(f2); File.Delete(f3); File.Delete(f4);
+        }
+    }
+
+    // =========================================================================
+    // BuildStatus — CheckedAtUtc
+    // =========================================================================
+
+    [Test]
+    public async Task BuildStatus_CheckedAtUtc_IsRecent()
+    {
+        var before = DateTimeOffset.UtcNow;
+        var status = ExecutableReadinessMonitor.BuildStatus(new AppSettings());
+        var after = DateTimeOffset.UtcNow;
+
+        await Assert.That(status.CheckedAtUtc).IsGreaterThanOrEqualTo(before);
+        await Assert.That(status.CheckedAtUtc).IsLessThanOrEqualTo(after);
+    }
+}

--- a/Vod2Tube.Web/Program.cs
+++ b/Vod2Tube.Web/Program.cs
@@ -45,7 +45,10 @@ builder.Services.AddScoped<VideoUploader>();
 builder.Services.AddScoped<VodDownloader>();
 builder.Services.AddScoped<YouTubeAccountService>();
 
+builder.Services.AddSingleton<ExecutableReadinessMonitor>();
+
 builder.Services.AddHostedService<VodPopulator>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<ExecutableReadinessMonitor>());
 builder.Services.AddHostedService<JobManager>();
 
 var app = builder.Build();


### PR DESCRIPTION
Require binaries like ffmpeg to exist before running jobs. 
Includes a notice on the web interface